### PR TITLE
Updated api call version

### DIFF
--- a/asyncsector/asyncsector.py
+++ b/asyncsector/asyncsector.py
@@ -13,7 +13,7 @@ class AsyncSector(object):
     Temperatures = 'Panel/GetTempratures/'
     History = 'Panel/GetPanelHistory/{}'
     Arm = 'Panel/ArmPanel'
-    Version = 'v1_1_64'
+    Version = 'v1_1_66'
 
     @classmethod
     async def create(cls, session, alarm_id, username, password):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Temperature data errored out with 'wrong version' when using v1.1.64.