### PR TITLE
Automatically use current api version

### DIFF
--- a/asyncsector/__main__.py
+++ b/asyncsector/__main__.py
@@ -26,11 +26,18 @@ async def async_main(loop):
     parser.add_argument('--repeat', type=int, default=1)
     parser.add_argument('--delay', type=int, default=10)
     parser.add_argument('--history', type=int, default=1)
-    parser.add_argument('--version', type=str, default=None)
+    parser.add_argument('--version', type=str, default=None, help='Version string or "auto"')
+    parser.add_argument('--getversion',dest='getversion',action='store_true')
+    parser.set_defaults(getversion=False)
 
     args = parser.parse_args()
 
     async with aiohttp.ClientSession(loop=loop) as session:
+
+        if args.getversion:
+            version = await AsyncSector.getapiversion(session)
+            print(version)
+            return
 
         alarm = await AsyncSector.create(session,
                                          args.alarm_id, args.username, args.password, args.version)
@@ -71,4 +78,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-    
+

--- a/asyncsector/asyncsector.py
+++ b/asyncsector/asyncsector.py
@@ -2,6 +2,7 @@
 import async_timeout
 
 from .util import get_json
+from .util import find_version
 
 
 class AsyncSector(object):
@@ -15,9 +16,25 @@ class AsyncSector(object):
     Arm = 'Panel/ArmPanel'
     Version = 'v1_1_68'
 
+    @staticmethod
+    async def getapiversion(session):
+        """ Tries to retrieve current API version """
+
+        with async_timeout.timeout(10):
+            response = await session.get(
+                AsyncSector.Base, json=None)
+
+            if response.status == 200:
+                result = await response.text()
+                return find_version(result) if result else None
+
+        return None
+
     @classmethod
     async def create(cls, session, alarm_id, username, password, version=None):
         """ factory """
+        if version == 'auto':
+            version = await AsyncSector.getapiversion(session)
         self = AsyncSector(session, alarm_id, username, password, version)
         logged_in = await self.login()
 

--- a/asyncsector/util.py
+++ b/asyncsector/util.py
@@ -5,6 +5,7 @@ import asyncio
 
 import async_timeout
 
+import re
 
 async def get_json(request):
     '''
@@ -35,3 +36,11 @@ def get_time(time):
     unix_timestamp = time.split('(')[1][:-2]
     date = datetime.datetime.fromtimestamp(int(unix_timestamp) / 1000)
     return date.isoformat()
+
+def find_version(string):
+    '''
+    Takes an html output and returns version string, if found
+    '''
+
+    r=re.search('v\d+_\d+_\d+',string)
+    return r.group(0) if r else None


### PR DESCRIPTION
Adresses #12

--version=auto will first send an empty request to get the current
version string, and then use this value

--getversion should just return current version
(still requires alarm_id, username password, can be dummies)